### PR TITLE
Fix issues with redundant and duplicate assertions

### DIFF
--- a/example/tests/test_duplicate_unittest.py
+++ b/example/tests/test_duplicate_unittest.py
@@ -6,6 +6,9 @@ class SomeClass(unittest.TestCase):
     def test_something(self):
         assert 1 == 1
         self.assertFalse(1 == 2)
+        self.assertFalse(1 == 2)
+        self.assertFalse(1 == 2)
+        assert 1 == 1
         assert 1 == 1
 
     def test_something_else(self):

--- a/example/tests/test_redundant_assertion_unittest.py
+++ b/example/tests/test_redundant_assertion_unittest.py
@@ -5,6 +5,10 @@ class SomeClass(unittest.TestCase):
 
     def test_something(self):
         assert 1 == 1
+        self.assertTrue(1)
+        self.assertEqual(2, 3)
+        self.assertTrue()
+        self.assertEqual(1, 1)
 
     def do_something(self):
         assert 2 < 2
@@ -15,8 +19,11 @@ class SomeClass(unittest.TestCase):
 
 class OtherClass(unittest.TestCase):
 
+    def test_somethin_other(self):
+        assert 1 == 1
+
     def test_something_other(self):
-        self.assertTrue(4 >= 4)
+        self.assertTrue(4 <= 4)
 
 
 class AnotherClass:

--- a/plugin/src/main/kotlin/org/jetbrains/research/pynose/plugin/inspections/common/RedundantAssertionTestSmellVisitor.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/research/pynose/plugin/inspections/common/RedundantAssertionTestSmellVisitor.kt
@@ -28,18 +28,18 @@ open class RedundantAssertionTestSmellVisitor(holder: ProblemsHolder?, session: 
 
     override fun visitPyAssertStatement(assertStatement: PyAssertStatement) {
         super.visitPyAssertStatement(assertStatement)
-        val expressions = assertStatement.arguments
-        if (expressions.isEmpty() || !GeneralInspectionsUtils.checkValidParent(assertStatement)) {
+        val args = assertStatement.arguments
+        if (args.isEmpty() || !GeneralInspectionsUtils.checkValidParent(assertStatement)) {
             return
         }
-        if (expressions[0] is PyLiteralExpression) {
+        if (args[0] is PyLiteralExpression) {
             registerRedundant(assertStatement)
             return
         }
-        if (expressions[0] !is PyBinaryExpression) {
+        if (args[0] !is PyBinaryExpression) {
             return
         }
-        val binaryExpression = expressions[0] as PyBinaryExpression
+        val binaryExpression = args[0] as PyBinaryExpression
         val psiOperator = binaryExpression.psiOperator ?: return
         if (binaryExpression.children.size < 2) {
             return

--- a/plugin/src/main/kotlin/org/jetbrains/research/pynose/plugin/inspections/unittest/RedundantAssertionTestSmellUnittestInspection.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/research/pynose/plugin/inspections/unittest/RedundantAssertionTestSmellUnittestInspection.kt
@@ -15,22 +15,22 @@ class RedundantAssertionTestSmellUnittestInspection : AbstractTestSmellInspectio
 
     override fun buildUnittestVisitor(holder: ProblemsHolder, session: LocalInspectionToolSession): PsiElementVisitor {
         return object : RedundantAssertionTestSmellVisitor(holder, session) {
-            // todo: assertTrue(4 < 4) is not detected
+            // todo: assertTrue(x < x) is not detected
             override fun visitPyCallExpression(callExpression: PyCallExpression) {
                 super.visitPyCallExpression(callExpression)
-                val child = callExpression.callee
-                if (child !is PyReferenceExpression || !UnittestInspectionsUtils.isUnittestCallAssertMethod(child)
+                val callee = callExpression.callee ?: return
+                if (callee !is PyReferenceExpression || !UnittestInspectionsUtils.isUnittestCallAssertMethod(callee)
                     || !UnittestInspectionsUtils.isValidUnittestParent(callExpression)
                 ) {
                     return
                 }
                 val argList = callExpression.getArguments(null)
-                if (UnittestInspectionsUtils.ASSERT_METHOD_ONE_PARAM.containsKey(child.name)) {
-                    if (argList[0].text == UnittestInspectionsUtils.ASSERT_METHOD_ONE_PARAM[child.name]) {
+                if (UnittestInspectionsUtils.ASSERT_METHOD_ONE_PARAM.containsKey(callee.name)) {
+                    if (argList.isNotEmpty() && argList[0].text == UnittestInspectionsUtils.ASSERT_METHOD_ONE_PARAM[callee.name]) {
                         registerRedundant(callExpression)
                     }
-                } else if (UnittestInspectionsUtils.ASSERT_METHOD_TWO_PARAMS.contains(child.name)) {
-                    if (argList[0].text == argList[1].text) {
+                } else if (UnittestInspectionsUtils.ASSERT_METHOD_TWO_PARAMS.contains(callee.name)) {
+                    if (argList.size >= 2 && argList[0].text == argList[1].text) {
                         registerRedundant(callExpression)
                     }
                 }

--- a/plugin/src/main/kotlin/org/jetbrains/research/pynose/plugin/quickfixes/common/DuplicateAssertionTestSmellQuickFix.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/research/pynose/plugin/quickfixes/common/DuplicateAssertionTestSmellQuickFix.kt
@@ -3,6 +3,8 @@ package org.jetbrains.research.pynose.plugin.quickfixes.common
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.openapi.project.Project
+import com.jetbrains.python.psi.PyAssertStatement
+import com.jetbrains.python.psi.PyCallExpression
 import org.jetbrains.research.pynose.plugin.util.TestSmellBundle
 
 class DuplicateAssertionTestSmellQuickFix : LocalQuickFix {
@@ -11,6 +13,11 @@ class DuplicateAssertionTestSmellQuickFix : LocalQuickFix {
     }
 
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        descriptor.psiElement.delete()
+        val assertion = descriptor.psiElement
+        if (assertion is PyCallExpression) {
+            assertion.parent.delete()
+        } else if (assertion is PyAssertStatement) {
+            assertion.delete()
+        }
     }
 }

--- a/plugin/src/main/kotlin/org/jetbrains/research/pynose/plugin/quickfixes/common/RedundantAssertionTestSmellQuickFix.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/research/pynose/plugin/quickfixes/common/RedundantAssertionTestSmellQuickFix.kt
@@ -3,6 +3,8 @@ package org.jetbrains.research.pynose.plugin.quickfixes.common
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.openapi.project.Project
+import com.jetbrains.python.psi.PyAssertStatement
+import com.jetbrains.python.psi.PyCallExpression
 import org.jetbrains.research.pynose.plugin.util.TestSmellBundle
 
 class RedundantAssertionTestSmellQuickFix : LocalQuickFix {
@@ -11,6 +13,11 @@ class RedundantAssertionTestSmellQuickFix : LocalQuickFix {
     }
 
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        descriptor.psiElement.delete()
+        val assertion = descriptor.psiElement
+        if (assertion is PyCallExpression) {
+            assertion.parent.delete()
+        } else if (assertion is PyAssertStatement) {
+            assertion.delete()
+        }
     }
 }


### PR DESCRIPTION
This one should better be merged before the one with test runner to avoid conflicts.
The same issue occured in duplicate assertion inspection so I fixed them both here